### PR TITLE
Handle IndexError and some boilerplate

### DIFF
--- a/ephemetoot.py
+++ b/ephemetoot.py
@@ -72,6 +72,7 @@ def checkToots(timeline, deleted_count=0):
       print('No toots found!')
 
 # trigger from here
-account = mastodon.account(user_id)
-print('Checking ' + str(account.statuses_count) + ' toots...')
-checkToots(timeline)
+if __name__ == '__main__':
+  account = mastodon.account(user_id)
+  print('Checking ' + str(account.statuses_count) + ' toots...')
+  checkToots(timeline)

--- a/ephemetoot.py
+++ b/ephemetoot.py
@@ -61,12 +61,15 @@ def checkToots(timeline, deleted_count=0):
   # the account_statuses call is paginated with a 40-toot limit
   # get the id of the last toot to include as 'max_id' in the next API call.
   # then keep triggering new rounds of checkToots() until there are no more toots to check
-  max_id = timeline[-1:][0].id
-  next_batch = mastodon.account_statuses(user_id, limit=40, max_id=max_id)
-  if len(next_batch) > 0:
-    checkToots(next_batch, deleted_count)
-  else: 
-    print('Removed ' + str(deleted_count) + ' toots.')
+  try:
+    max_id = timeline[-1:][0].id
+    next_batch = mastodon.account_statuses(user_id, limit=40, max_id=max_id)
+    if len(next_batch) > 0:
+      checkToots(next_batch, deleted_count)
+    else:
+      print('Removed ' + str(deleted_count) + ' toots.')
+  except IndexError:
+      print('No toots found!')
 
 # trigger from here
 account = mastodon.account(user_id)


### PR DESCRIPTION
- When you run ephemetoot on an account with no toots, it throws an `IndexError`. Add a try block to fix this.
- add the traditional `if __name__ == '__main__':`