### PR TITLE
Rate limit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Based partially on [tweet-deleting script](https://gist.github.com/flesueur/bcb2
 
 # Usage
 
-You can use this script to delete [Mastodon](https://github.com/tootsuite/mastodon) toots that are older than a certain number of days. By default it will keep any pinned toots, but you can change that in `config.py` if you want them to be deleted. You can also make a list toots that you want to save, by adding the ID numbers to the `toots_to_save` list in `config.py` (see point 9 below). The ID of a toot is the last part of its individual URL. e.g. for https://ausglam.space/@hugh/101294246770105799 the id is `101294246770105799`
+You can use this script to delete [Mastodon](https://github.com/tootsuite/mastodon) toots that are older than a certain number of days. By default it will keep any pinned toots, but you can change `save_pinned` to `False` in `config.py` if you want them to be deleted. You can also make a list toots that you want to save, by adding the ID numbers to the `toots_to_save` list in `config.py` (see point 9 below). The ID of a toot is the last part of its individual URL. e.g. for https://ausglam.space/@hugh/101294246770105799 the id is `101294246770105799`
 
 This script requires Python3, the `mastodon.py` package and an API access token.
 
@@ -42,8 +42,6 @@ Run the script with no flags: `python3 ephemetoot.py`.
 
 Depending on how many toots you have and how long you want to keep them, it may take a minute or two before you see any results.
 
-Note that the Mastodon API limits toot deletions to 30 deletes per 30 minutes. If you are running `ephemetoot` for the first time and have a lot of toots to delete, it may take a while as the script will pause for 30 minutes when it reaches a multiple of 30 deletions.
-
 ## Scheduling
 
 Deleting old toots daily is the best approach to keeping your timeline clean and avoiding problems wiht the API rate limit.
@@ -53,6 +51,10 @@ To run automatically every day you could try using crontab:
   2. `@daily python3 ~/ephemetoot/ephemetoot.py`
 
 Alternatively on MacOS you could use [launchd](https://www.launchd.info/). An install script to set up automation with launchd is [on the list](https://github.com/hughrun/ephemetoot/issues/5) of things to be done.
+
+## Rate limits
+
+As of v2.7.2 the Mastodon API has a rate limit of 30 deletions per 30 minutes. `mastodon.py` automatically handles this. If you are running `ephemetoot` for the first time and/or have a lot of toots to delete, it may take a while as the script will pause when it hits a rate limit, until the required time has expired.
 
 # Bugs and suggestions
 

--- a/ephemetoot.py
+++ b/ephemetoot.py
@@ -24,7 +24,7 @@
 from argparse import ArgumentParser
 import config
 import json
-from mastodon import Mastodon
+from mastodon import Mastodon, MastodonError
 from datetime import datetime, timedelta, timezone
 import time
 
@@ -38,7 +38,7 @@ if options.test:
 
 print("Fetching account details...")
 
-mastodon = Mastodon(access_token=config.access_token, api_base_url=config.base_url)
+mastodon = Mastodon(access_token=config.access_token, api_base_url=config.base_url, ratelimit_method="wait")
 
 cutoff_date = datetime.now(timezone.utc) - timedelta(days=config.days_to_keep)
 user_id = mastodon.account_verify_credentials().id
@@ -72,24 +72,30 @@ def checkToots(timeline, deleted_count=0):
                         + toot.created_at.strftime("%d %b %Y")
                     )
                     deleted_count += 1
+                    time.sleep(2) # wait 2 secs between deletes to be a bit nicer to the server
                     if not options.test:
-                        # the delete API call is limited to 30 deletions every 30 minutes
-                        if (deleted_count == 30) or (
-                            deleted_count > 30 and (deleted_count % 30 == 0)
-                        ):
-                            mastodon.status_delete(toot)
-                            print(
-                                "waiting 30 minutes: API limit reached at "
-                                + str(deleted_count)
-                                + " deletions"
-                            )
-                            time.sleep(
-                                1805
-                            )  # wait 30 minnutes with 5 extra seconds leeway
-                        else:
-                            mastodon.status_delete(toot)
-        except:
-            print("🛑 **error** with toot - " + str(toot.id))
+                        mastodon.status_delete(toot)
+        except MastodonError as e:
+            print("🛑 ERROR deleting toot - " + str(toot.id) + " - " + e.args[3])
+            print("Waiting 1 minute before re-trying...")
+            time.sleep(
+                60
+            )
+            try:
+                print("Attempting delete again")
+                mastodon.status_delete(toot)
+                time.sleep(2) # wait 2 secs between deletes to be a bit nicer to the server
+            except Exception as e:
+                print("🛑 ERROR deleting toot - " + str(toot.id))
+                print(e)
+                print("Exiting due to error.")
+                break
+        except KeyboardInterrupt:
+            print("Operation aborted.")
+            break
+        except Exception as e:
+          print("🛑 Unknown ERROR deleting toot - " + str(toot.id))
+          print(e)
 
     # the account_statuses call is paginated with a 40-toot limit
     # get the id of the last toot to include as 'max_id' in the next API call.

--- a/ephemetoot.py
+++ b/ephemetoot.py
@@ -38,7 +38,11 @@ if options.test:
 
 print("Fetching account details...")
 
-mastodon = Mastodon(access_token=config.access_token, api_base_url=config.base_url, ratelimit_method="wait")
+mastodon = Mastodon(
+    access_token=config.access_token,
+    api_base_url=config.base_url,
+    ratelimit_method="wait",
+)
 
 cutoff_date = datetime.now(timezone.utc) - timedelta(days=config.days_to_keep)
 user_id = mastodon.account_verify_credentials().id
@@ -72,19 +76,21 @@ def checkToots(timeline, deleted_count=0):
                         + toot.created_at.strftime("%d %b %Y")
                     )
                     deleted_count += 1
-                    time.sleep(2) # wait 2 secs between deletes to be a bit nicer to the server
+                    time.sleep(
+                        2
+                    )  # wait 2 secs between deletes to be a bit nicer to the server
                     if not options.test:
                         mastodon.status_delete(toot)
         except MastodonError as e:
             print("🛑 ERROR deleting toot - " + str(toot.id) + " - " + e.args[3])
             print("Waiting 1 minute before re-trying...")
-            time.sleep(
-                60
-            )
+            time.sleep(60)
             try:
                 print("Attempting delete again")
                 mastodon.status_delete(toot)
-                time.sleep(2) # wait 2 secs between deletes to be a bit nicer to the server
+                time.sleep(
+                    2
+                )  # wait 2 secs between deletes to be a bit nicer to the server
             except Exception as e:
                 print("🛑 ERROR deleting toot - " + str(toot.id))
                 print(e)
@@ -94,8 +100,8 @@ def checkToots(timeline, deleted_count=0):
             print("Operation aborted.")
             break
         except Exception as e:
-          print("🛑 Unknown ERROR deleting toot - " + str(toot.id))
-          print(e)
+            print("🛑 Unknown ERROR deleting toot - " + str(toot.id))
+            print(e)
 
     # the account_statuses call is paginated with a 40-toot limit
     # get the id of the last toot to include as 'max_id' in the next API call.


### PR DESCRIPTION
This removes the recent changes I made for rate-limiting, since mastodon.py handles this automatically - there's no point adding extra complexity.

Also adds some additional exception handling to make it easier to understanding what's happening with there is an error or exception.