### PR TITLE
Rate limit notification

### DIFF
--- a/ephemetoot.py
+++ b/ephemetoot.py
@@ -79,6 +79,8 @@ def checkToots(timeline, deleted_count=0):
                     time.sleep(
                         2
                     )  # wait 2 secs between deletes to be a bit nicer to the server
+                    if mastodon.ratelimit_remaining == 0:
+                        print("Rate limit reached. Waiting for a rate limit reset...")
                     if not options.test:
                         mastodon.status_delete(toot)
         except MastodonError as e:

--- a/ephemetoot.py
+++ b/ephemetoot.py
@@ -67,6 +67,10 @@ def checkToots(timeline, deleted_count=0):
                     deleted_count += 1
                     # unreblog the original toot (their toot), not the toot created by boosting (your toot)
                     if not options.test:
+                        if mastodon.ratelimit_remaining == 0:
+                            print(
+                                "Rate limit reached. Waiting for a rate limit reset..."
+                            )
                         mastodon.status_unreblog(toot.reblog)
                 else:
                     print(
@@ -79,9 +83,11 @@ def checkToots(timeline, deleted_count=0):
                     time.sleep(
                         2
                     )  # wait 2 secs between deletes to be a bit nicer to the server
-                    if mastodon.ratelimit_remaining == 0:
-                        print("Rate limit reached. Waiting for a rate limit reset...")
                     if not options.test:
+                        if mastodon.ratelimit_remaining == 0:
+                            print(
+                                "Rate limit reached. Waiting for a rate limit reset..."
+                            )
                         mastodon.status_delete(toot)
         except MastodonError as e:
             print("🛑 ERROR deleting toot - " + str(toot.id) + " - " + e.args[3])


### PR DESCRIPTION
Provides a message to the console when the rate limit is reached.

I'm not sure how the internals of `mastodon.ratelimit_remaining` work, so I'm not sure how it counts or distinguishes between the rate limits for toots vs. deletes vs. unreblogs. It just returns an integer.

The bug I know of is that if you start the script when you've already exhausted your limit, you wont get the rate limit message right off the bat.