### PR TITLE
Fix wrong config strings in example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This script requires Python3, the `mastodon.py` package and an API access token.
 5. Replace `YOUR_ACCESS_TOKEN_HERE` in config.py with the access token string
 6. Set the `base_url` to match your mastodon server
 7. Set the `days_to_keep` to the number of days you want to keep toots before deleting them
-8. If you do **not** wish to keep all pinned toots regardless of age, change `save_pinned` to `False`
+8. If you do **not** wish to keep all pinned toots regardless of age, change `keep_pinned` to `False`
 9. If there are any other toots you want to keep, put the ID numbers (without quotes) in the `toots_to_keep` list, separated by commas. For example:
 ```python
 toots_to_keep = [100029521330725397, 100013562864734780, 100044187305250752]

--- a/example.config.py
+++ b/example.config.py
@@ -1,7 +1,7 @@
 access_token = 'YOUR_ACCESS_TOKEN_HERE'
 base_url = 'https://ausglam.space'
 days_to_keep = 30
-save_pinned = True
-toots_to_save = []
+keep_pinned = True
+toots_to_keep = []
 hashtags_to_keep = {'introduction', 'announcement'} # comma separated Set as strings, e.g. 'introduction'
 visibility_to_keep = ['private', 'unlisted'] # options are: 'public', 'unlisted', 'private', 'direct'


### PR DESCRIPTION
This fixes the errors:
> module 'config' has no attribute 'keep_pinned'

and:
> module 'config' has no attribute 'keep_pinned'