### PR TITLE
Add support for archiving toots into JSON files

### DIFF
--- a/lib/ephemetoot.py
+++ b/lib/ephemetoot.py
@@ -82,6 +82,7 @@ def checkToots(config, options, retry_count=0):
         def jsondefault(obj):
             if isinstance(obj, (date, datetime)):
                 return obj.isoformat()
+
         def checkBatch(timeline, deleted_count=0):
             for toot in timeline:
                 if 'id' in toot and 'archive' in config:

--- a/lib/ephemetoot.py
+++ b/lib/ephemetoot.py
@@ -85,7 +85,6 @@ def checkToots(config, options, retry_count=0):
         def checkBatch(timeline, deleted_count=0):
             for toot in timeline:
                 if 'id' in toot and 'archive' in config:
-                    print(toot)
                     filename = os.path.join(config['archive'], str(toot['id']) + '.json')
                     with open(filename, "w") as f:
                         f.write(json.dumps(toot, indent=4, default=jsondefault))


### PR DESCRIPTION
Thank you for a very useful utility. I've found it practical in the past to archive a local copy of what I'm about to delete if only to refresh my memory at a later point in time. :-)

This small patch adds such a feature. If an `archive` is configured, it should be a writeable directory into which _ephemetoot_ will dump indented JSON into files named by the Toot's `id` (as this is something we can consider unique).