### PR TITLE
Fix typo in README on copying the example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ As of version 2, you can use a single `ephemetoot` installation to delete toots 
 
 Copy `example-config.yaml` to a new file called `config.yaml`:
 ```shell
-cp example-config.yam config.yaml
+cp example-config.yaml config.yaml
 ```
 You can now enter the configuration details for each user:
 


### PR DESCRIPTION
Fixes a typo in the Config documentation

**Changes in this pull request**

Before the config file said `cp example-config.yam config.yaml`

This fixes the typo and now says `cp example-config.yaml config.yaml`

Resolves #39 