### PR TITLE
Add option to further suppress output

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -69,7 +69,7 @@ If you skip a lot of items (e.g. you skip direct messages) it may clutter your l
 
 ### Hide everything (--quiet)
 
-Use the `--quiet` flag to suppress all logging except for the account name being checked and the number of toots deleted. Exception messages will not be suppressed.
+Use the `--quiet` or `-q` flag to suppress all logging except for the account name being checked and the number of toots deleted. Use the `-qq` flag to further suppress output for accounts with zero deleted toots. The `-qqq` flag will suppress all output. Exception messages will not be suppressed.
 
 ### Only archive deleted toots (--archive-deleted)
 

--- a/ephemetoot/console.py
+++ b/ephemetoot/console.py
@@ -72,7 +72,12 @@ parser.add_argument(
     action="store_true",
     help="Slow deletion actions to match API rate limit to avoid pausing",
 )
-parser.add_argument("--quiet", action="store_true", help="Suppress most logging")
+parser.add_argument(
+    "-q",
+    "--quiet",
+    action="count",
+    help="Limits logging to one line per account. Use -qq to limit logging to accounts with deleted toots and -qqq to completely suppress logging.",
+)
 parser.add_argument(
     "--retry-mins",
     action="store",

--- a/ephemetoot/ephemetoot.py
+++ b/ephemetoot/ephemetoot.py
@@ -437,7 +437,21 @@ def check_batch(config, options, mastodon, user_id, timeline, deleted_count=0):
                 if options.datestamp:
                     print("\n", datestamp_now(), end=" : ")
 
-                print("Removed " + str(deleted_count) + " toots.\n")
+                # options.quiet can be None
+                if (
+                    (not options.quiet)
+                    or options.quiet <= 1
+                    or (options.quiet == 2 and deleted_count)
+                ):
+                    print(
+                        "Removed "
+                        + str(deleted_count)
+                        + " toots for "
+                        + config["username"]
+                        + "@"
+                        + config["base_url"]
+                        + ".\n"
+                    )
 
                 if not options.quiet:
                     print("---------------------------------------")
@@ -471,13 +485,14 @@ def check_toots(config, options, retry_count=0):
     The main function, uses the Mastodon API to check all toots in the user timeline, and delete any that do not meet any of the exclusion criteria from the config file.
     """
     try:
-        print(
-            "Fetching account details for @",
-            config["username"],
-            "@",
-            config["base_url"],
-            sep="",
-        )
+        if not options.quiet:
+            print(
+                "Fetching account details for @",
+                config["username"],
+                "@",
+                config["base_url"],
+                sep="",
+            )
 
         if options.pace:
             mastodon = Mastodon(

--- a/tests/test_ephemetoot.py
+++ b/tests/test_ephemetoot.py
@@ -239,7 +239,7 @@ def test_check_batch(capfd, monkeypatch):
     ephemetoot.check_batch(config, options, mastodon, user_id, timeline, 0)
     # deleted_count should be 10
     output = capfd.readouterr().out.split("\n")
-    assert output[0] == "Removed 10 toots."
+    assert output[0] == "Removed 10 toots for alice@test.social."
 
 
 def test_console_print(capfd):


### PR DESCRIPTION
This commit adds the ability to further suppress output for accounts with no deleted toots using the `-qq` flag. It alsoadds the option to completely suppress logging (excluding exceptions) by using the `-qqq` flag

## Styles and docs

- [X] I have read the [contributing guide](https://github.com/hughrun/ephemetoot/blob/master/docs/contributing.md)
- [X] I have run `black` on my code
- [x] My tests are listed in alphabetical order

## Tests

I'm not sure if/how you want me to test this. I modified `test_check_batch` to test for the new logging format but the tests don't cover the quiet cases.

- [ ] I have added tests for this code in `tests/test_ephemetoot.py`
- [X] I would like assistance to write the required tests
- [ ] I don't know how to write test and would like someone to write them for me

# What this PR does

Changes in this pull request
- Adds `-q` to the `--quiet` options and switches the target from `store_true` to `count`
- Add `user@base_url` to `Deleted X toots` message
- Suppress output when `options.quiet == 2` and `deleted_toots == 0` or when `options.quiet >= 3`

# Related issues

Resolves #56 