### PR TITLE
Use HTTPS URL for link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 🥳 ==> 🧼 ==> 😇
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)  
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)  
 
 **ephemetoot** is a Python command line tool for deleting old toots.
 


### PR DESCRIPTION
Because HTTPS is more secure.

## Styles and docs

- [x] I have read the [contributing guide](https://github.com/hughrun/ephemetoot/blob/master/docs/contributing.md)
- [ ] I have run `black` on my code, no trivial/doc change
- [x] My tests are listed in alphabetical order, no tests, trivial/doc change

## Tests

- [x] I have added tests for this code in `tests/test_ephemetoot.py`, no trivial/doc change
- [ ] I would like assistance to write the required tests, no trivial/doc change
- [ ] I don't know how to write test and would like someone to write them for me, no trivial/doc change

# What this PR does

Changes in this pull request
- Use HTTPS URL for a link in the Readme.

# Related issues

N/A