### PR TITLE
remove setuptools runtime dependency

### DIFF
--- a/ephemetoot/console.py
+++ b/ephemetoot/console.py
@@ -30,13 +30,13 @@ import yaml
 from argparse import ArgumentParser
 from datetime import datetime, timezone
 import os
-import pkg_resources
+from importlib.metadata import version
 
 # import funtions
 from ephemetoot import ephemetoot as func
 
 # version number from package info
-vnum = pkg_resources.require("ephemetoot")[0].version
+vnum = version("ephemetoot")
 
 parser = ArgumentParser()
 parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.8"
 requests = "^2.22.0"
 "mastodon.py" = "^1.4.3"
 pyyaml = "^5.0"


### PR DESCRIPTION
## Styles and docs

- [X] I have read the [contributing guide](https://github.com/hughrun/ephemetoot/blob/master/docs/contributing.md)
- [X] I have run `black` on my code
- [ ] My tests are listed in alphabetical order

## Tests

- [ ] I have added tests for this code in `tests/test_ephemetoot.py`
- [ ] I would like assistance to write the required tests
- [ ] I don't know how to write test and would like someone to write them for me

# What this PR does

This removes setuptools as a runtime dependency.  It seems to be only used to display the package version.  A user of the OpenBSD port for ephemetoot noticed that this was needed.
I used `importlib.metadata`, which is in Python core now.  Unfortunately, this is only present on Python 3.8 onwards (I think), so I changed that too onthe pyproject.toml.

By the way, even if we're at 3.1.3, pyproject.toml still has 3.1.2.  I did not touch that in case there's a good reason for it.